### PR TITLE
feat: bump library release_status to beta

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/solutions/talent-solution/",
   "client_documentation": "https://googleapis.dev/python/talent/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559664",
-  "release_level": "alpha",
+  "release_level": "beta",
   "language": "python",
   "repo": "googleapis/python-talent",
   "distribution_name": "google-cloud-talent",

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-Python Client for Cloud Talent Solution API (`Alpha`_)
+Python Client for Cloud Talent Solution API
 ======================================================
 
-
+|beta| |pypi| |versions| 
 
 `Cloud Talent Solution API`_: Cloud Talent Solution provides the capability to create, read, update, and
 delete job postings, as well as search jobs based on keywords and filters.
@@ -9,7 +9,12 @@ delete job postings, as well as search jobs based on keywords and filters.
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-talent.svg
+   :target: https://pypi.org/project/google-cloud-talent/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-talent.svg
+   :target: https://pypi.org/project/google-cloud-talent/
 .. _Cloud Talent Solution API: https://cloud.google.com/jobs
 .. _Client Library Documentation: https://googleapis.dev/python/talent/latest
 .. _Product Documentation:  https://cloud.google.com/jobs

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ version = "0.5.0"
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
-release_status = "Development Status :: 3 - Alpha"
+release_status = "Development Status :: 4 - Beta"
 dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 


### PR DESCRIPTION
Underlying API is beta [v4beta1](https://github.com/googleapis/python-talent/tree/master/google/cloud)